### PR TITLE
Fix sudo unprettified json

### DIFF
--- a/wifi_positioning_system.py
+++ b/wifi_positioning_system.py
@@ -276,10 +276,7 @@ def check_prerequisites():
                 #      perm_cmd.split() + [
                 #          ' '.join(['./' + sys.argv[0].lstrip('./')] + sys.argv[1:])
                 #      ]
-                os.execvp(perm_cmd.split()[0],
-                          perm_cmd.split() + [
-                              ' '.join(['./' + sys.argv[0].lstrip('./')] + sys.argv[1:])
-                          ])
+                os.execvp(perm_cmd.split()[0], perm_cmd.split() + sys.argv )
 
             which_iw_status, which_iw_result = getstatusoutput('which iw')
             if which_iw_status != 0:

--- a/wifi_positioning_system.py
+++ b/wifi_positioning_system.py
@@ -55,7 +55,7 @@ def prettify_json(json_data):
     if args.json_prettify:
         return '\n'.join([l.rstrip() for l in simplejson.dumps(json_data, sort_keys=True, indent=4*' ').splitlines()])
     else:
-        return json_data
+        return simplejson.dumps(json_data)
 
 
 def create_overview(api_result, filename='Wifi_geolocation.html', filepath=get_scriptpath()):


### PR DESCRIPTION
Fixes non valid unprettified JSON output and restart with sudo.

prior to the fix JSON output was invalid.

Running the script as a non privileged user gave:
```
% /wifi_positioning_system.py -i wlan0                                                                                
sudo: ./wifi_positioning_system.py -i wlan0: command not found
```
and when called via python:
```
% python ./wifi_positioning_system.py -i wlan0                                                                                               [I]
sudo: wifi_positioning_system.py: command not found
```